### PR TITLE
fix: backticks being allowed when not using string interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-default-export': 'error',
     'import/prefer-default-export': 'off',
+    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
   },
 };


### PR DESCRIPTION
Current behavior:

![image](https://github.com/Avenue3-dev/eslint-config-avenue3/assets/149682495/de4a7f4e-364a-4701-8b05-82a8383d7dce)

![image](https://github.com/Avenue3-dev/eslint-config-avenue3/assets/149682495/23f64e89-f598-43e5-8ee4-25cf873eb72f)

New behavior:

![image](https://github.com/Avenue3-dev/eslint-config-avenue3/assets/149682495/31c7a37a-adaa-4b12-8f8c-914324195dfc)

![image](https://github.com/Avenue3-dev/eslint-config-avenue3/assets/149682495/f5d28d58-dff1-4b73-b35f-9bdde5aa8110)