### PR TITLE
fix: update react/jsx-key rule to enforce keys for fragments

### DIFF
--- a/react.js
+++ b/react.js
@@ -26,5 +26,6 @@ module.exports = {
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
     'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    'react/jsx-key': ['error', { checkFragmentShorthand: true }],
   },
 };


### PR DESCRIPTION
When rendering lists in React you should use a key prop, more information as to why can be found [here](https://react.dev/learn/rendering-lists#why-does-react-need-keys).

Our current config allows you to render lists without keys when using the shorthand fragment:

![image](https://github.com/Avenue3-dev/eslint-config-avenue3/assets/149682495/e560896f-8f7f-415e-a5fa-9e222e2c49a1)

According to React documentation we should not be using the shorthand:

![image](https://github.com/Avenue3-dev/eslint-config-avenue3/assets/149682495/117ecaef-082e-4f55-ad30-c644c674599c)

Based on the documentation for the `react/jsx-key` rule, we can prevent this from being allowed:

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md#rule-options

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md#rule-options